### PR TITLE
[WIP] Support secure text entry for commands

### DIFF
--- a/macos/src/appkit.rs
+++ b/macos/src/appkit.rs
@@ -87,6 +87,7 @@ impl_objc_class!(NSMenu);
 impl_objc_class!(NSMenuItem);
 impl_objc_class!(NSPasteboard);
 impl_objc_class!(NSResponder);
+impl_objc_class!(NSSecureTextField);
 impl_objc_class!(NSTextField);
 impl_objc_class!(NSView);
 impl_objc_class!(NSWindow);
@@ -284,6 +285,17 @@ impl NSPasteboard {
     }
 }
 
+impl NSSecureTextField {
+
+    pub fn new() -> Self {
+        NSSecureTextField { ptr: unsafe { msg_send![class!("NSSecureTextField"), new] } }
+    }
+
+    pub fn set_delegate<T: ObjCClass>(&self, delegate: &T) {
+        unsafe { msg_send![self.ptr, setDelegate:delegate.ptr()] }
+    }
+}
+
 impl NSTextField {
 
     pub fn new() -> Self {
@@ -292,6 +304,10 @@ impl NSTextField {
 
     pub fn set_delegate<T: ObjCClass>(&self, delegate: &T) {
         unsafe { msg_send![self.ptr, setDelegate:delegate.ptr()] }
+    }
+
+    pub fn set_placeholder(&self, text: &str) {
+        unsafe { msg_send![self.ptr, setPlaceholderString:NSString::from(text).ptr()] }
     }
 }
 

--- a/webkitten-cocoa/src/ui/window.rs
+++ b/webkitten-cocoa/src/ui/window.rs
@@ -282,14 +282,23 @@ fn layout_window_subviews(window: &NSWindow) {
 
     let container = WebViewContainerView::new().coerce::<NSView>().unwrap();
     let command_bar = NSTextField::new();
+    let secure_bar = NSSecureTextField::new();
     command_bar.set_delegate(&CommandBarDelegate::new());
     let ref config = super::UI.engine.config;
     let content_view = window.content_view().unwrap();
     let command_bar_view = command_bar.coerce::<NSView>().unwrap();
+    let secure_bar_view = secure_bar.coerce::<NSView>().unwrap();
+    secure_bar_view.set_hidden(true);
     content_view.add_subview(&container);
     content_view.add_subview(&command_bar_view);
+    content_view.add_subview(&secure_bar_view);
     command_bar_view.set_height(BAR_HEIGHT as CGFloat);
+    secure_bar_view.set_height(BAR_HEIGHT as CGFloat);
     command_bar_view.disable_translates_autoresizing_mask_into_constraints();
+    secure_bar_view.disable_translates_autoresizing_mask_into_constraints();
+    content_view.add_constraint(NSLayoutConstraint::bind(&secure_bar_view, NSLayoutAttribute::Bottom, &content_view, NSLayoutAttribute::Bottom));
+    content_view.add_constraint(NSLayoutConstraint::bind(&secure_bar_view, NSLayoutAttribute::Left, &content_view, NSLayoutAttribute::Left));
+    content_view.add_constraint(NSLayoutConstraint::bind(&secure_bar_view, NSLayoutAttribute::Right, &content_view, NSLayoutAttribute::Right));
     content_view.add_constraint(NSLayoutConstraint::bind(&command_bar_view, NSLayoutAttribute::Bottom, &content_view, NSLayoutAttribute::Bottom));
     content_view.add_constraint(NSLayoutConstraint::bind(&command_bar_view, NSLayoutAttribute::Left, &content_view, NSLayoutAttribute::Left));
     content_view.add_constraint(NSLayoutConstraint::bind(&command_bar_view, NSLayoutAttribute::Right, &content_view, NSLayoutAttribute::Right));


### PR DESCRIPTION
It would be nice to be able to request secured text from the command interface and keep it within the command bar flow. Drafting a rough sketch of how it might work.
## Scripting interface

There would need to be two components as text entry would probably be async. First, a new provided method to request text from the scripting interface:

``` lua
get_secure_text_input(“label”) -- “label” would appear as the placeholder in the secure text view
```

And a receipt hook:

``` lua
-- Provides variables for “secure_text” and “label"
function on_secure_text_input()
end
```
## Application UI

The scripting interface needs a new hook to invoke on `ui::ApplicationUI` for starting the secure input request.

``` rust
fn get_secure_text_input(&self, label: &str, window_index: u32);
```
## Event handler

The `ui::EventHandler` needs a new hook for handling successful secure text input, which handles getting the input to the scripting engine.

``` rust
fn on_secure_text_input(&self, label: &str, secure_text: &str, window_index: u32);
```
## Cocoa binding

The minimum viable password interface is something like presenting a sheet with a text field, or adding a new text field overlaying the command bar. In the latter case, it has to maybe have a different background color and show the label placeholder text.
- use `NSSecureTextField` with `echoesBullets` enabled
- Pressing return invokes `ui::EventHandler.on_secure_text_input(..)` to send the response to the scripting interface and hides the secure entry field
- Pressing esc hides the secure entry field without invoking the hook
- What to do if the command bar is focused instead…?

Will fix #18
