### PR TITLE
Session configurations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,9 @@ impl EventHandler for Engine {
 
     fn on_new_frame_request<T: ApplicationUI>(&self, ui: &T, window_index: u32, uri: &str) {
         if self.config.new_frame_uses_focused_window() {
-            ui.open_webview::<config::Config>(window_index, Some(uri), None);
+            ui.open_webview::<_, config::Config>(window_index, Some(uri), None);
         } else {
-            ui.open_window::<config::Config>(Some(uri), None);
+            ui.open_window::<_, config::Config>(Some(uri), None);
         }
     }
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -182,11 +182,11 @@ fn create_runtime<T: ApplicationUI>(ui: &T) -> Lua {
     }));
     lua.set("open_window", function1(|uri: String| {
         info!("open_window");
-        ui.open_window::<Config>(coerce_optional_str(uri.as_str()), None)
+        ui.open_window::<_, Config>(coerce_optional_str(uri), None)
     }));
     lua.set("open_custom_window", function2(|uri: String, config: String| {
         info!("open_window");
-        ui.open_window::<Config>(coerce_optional_str(uri.as_str()), Config::parse(&config))
+        ui.open_window(coerce_optional_str(uri), Config::parse(&config))
     }));
     lua.set("close_window", function1(|window_index: u32| {
         info!("close_window: {}", window_index);
@@ -210,11 +210,11 @@ fn create_runtime<T: ApplicationUI>(ui: &T) -> Lua {
     }));
     lua.set("open_webview", function2(|window_index: u32, uri: String| {
         info!("open_webview: {}", window_index);
-        ui.open_webview::<Config>(window_index, coerce_optional_str(uri.as_str()), None);
+        ui.open_webview::<_, Config>(window_index, coerce_optional_str(uri), None);
     }));
     lua.set("open_custom_webview", function3(|window_index: u32, uri: String, config: String| {
         info!("open_custom_webview: {} {}", window_index, config);
-        ui.open_webview::<Config>(window_index, coerce_optional_str(uri.as_str()), Config::parse(&config));
+        ui.open_webview::<_, Config>(window_index, coerce_optional_str(uri), Config::parse(&config));
     }));
     lua.set("webview_count", function1(|window_index: u32| {
         info!("get webview_count: {}", window_index);
@@ -302,7 +302,7 @@ fn coerce_optional_index(value: u32) -> Option<u32> {
     }
 }
 
-fn coerce_optional_str<'a, T: Into<&'a str>>(value: T) -> Option<&'a str> {
+fn coerce_optional_str<T: Into<String>>(value: T) -> Option<String> {
     let string = value.into();
     if string.is_empty() {
         return None;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -28,7 +28,9 @@ pub trait ApplicationUI: Sized {
     fn window_count(&self) -> u32;
 
     /// Open a new window
-    fn open_window<T: BrowserConfiguration>(&self, uri: Option<&str>, config: Option<T>) -> u32;
+    fn open_window<U, B>(&self, uri: Option<U>, config: Option<B>) -> u32
+        where U: Into<String>,
+              B: BrowserConfiguration;
 
     /// Close a window
     fn close_window(&self, index: u32);
@@ -71,7 +73,9 @@ pub trait ApplicationUI: Sized {
     fn webview_count(&self, window_index: u32) -> u32;
 
     /// Open a new webview in a specified window
-    fn open_webview<T: BrowserConfiguration>(&self, window_index: u32, uri: Option<&str>, config: Option<T>);
+    fn open_webview<'a, U, B>(&self, window_index: u32, uri: Option<U>, config: Option<B>)
+        where U: Into<String>,
+              B: BrowserConfiguration;
 
     /// Close a webview in a specified window
     fn close_webview(&self, window_index: u32, webview_index: u32);

--- a/webkitten-cocoa/src/runtime.rs
+++ b/webkitten-cocoa/src/runtime.rs
@@ -209,11 +209,11 @@ extern fn set_as_default_browser(_: &Object, _cmd: Sel) {
 extern fn open_file(_: &Object, _cmd: Sel, _app: Id, path: Id) -> BOOL {
     if let Some(path) = NSString::from_ptr(path).and_then(|s| s.as_str()) {
         let window_index = UI.focused_window_index()
-            .unwrap_or(UI.open_window::<Config>(None, None));
+            .unwrap_or(UI.open_window::<String, Config>(None, None));
         UI.focus_window(window_index);
         let mut protocol = String::from("file://");
         protocol.push_str(path);
-        UI.open_webview::<Config>(window_index, Some(&protocol), None);
+        UI.open_webview::<_, Config>(window_index, Some(protocol), None);
         return YES;
     }
     NO
@@ -233,9 +233,9 @@ extern fn handle_get_url(_: &Object, _cmd: Sel, event: Id, _reply_event: Id) {
         .and_then(|event| event.url_param_value())
         .and_then(|url| url.as_str());
     if let Some(window_index) = UI.focused_window_index() {
-        UI.open_webview::<Config>(window_index, url, None);
+        UI.open_webview::<_, Config>(window_index, url, None);
     } else {
-        UI.open_window::<Config>(url, None);
+        UI.open_window::<_, Config>(url, None);
     }
 }
 

--- a/webkitten-cocoa/src/ui/mod.rs
+++ b/webkitten-cocoa/src/ui/mod.rs
@@ -60,12 +60,10 @@ impl CocoaUI {
     fn open_first_window(&self) {
         if !self.engine.initial_pages().is_empty() {
             for page in self.engine.initial_pages() {
-                self.open_window::<Config>(Some(page.as_str()), None);
+                self.open_window::<_, Config>(Some(page.as_str()), None);
             }
-        } else if let Some(page) = self.engine.config.start_page() {
-            self.open_window::<Config>(Some(&page), None);
         } else {
-            self.open_window::<Config>(None, None);
+            self.open_window::<_, Config>(self.engine.config.start_page(), None);
         }
     }
 
@@ -105,9 +103,11 @@ impl ApplicationUI for CocoaUI {
         UI.engine.execute_command::<CocoaUI>(&UI, window_index, text);
     }
 
-    fn open_window<T: BrowserConfiguration>(&self, uri: Option<&str>, config: Option<T>) -> u32 {
-        if uri.is_some() {
-            window::open(uri, config)
+    fn open_window<U, B>(&self, uri: Option<U>, config: Option<B>) -> u32
+        where U: Into<String>,
+              B: BrowserConfiguration {
+        if let Some(uri) = uri {
+            window::open(Some(uri), config)
         } else {
             window::open(self.engine.config.start_page(), config)
         }
@@ -173,13 +173,13 @@ impl ApplicationUI for CocoaUI {
         window::webview_count(window_index)
     }
 
-    fn open_webview<T: BrowserConfiguration>(&self, window_index: u32, uri: Option<&str>, config: Option<T>) {
+    fn open_webview<U, B>(&self, window_index: u32, uri: Option<U>, config: Option<B>)
+        where U: Into<String>,
+              B: BrowserConfiguration {
         if let Some(uri) = uri {
-            window::open_webview(window_index, uri, config);
-        } else if let Some(uri) = self.engine.config.start_page() {
-            window::open_webview(window_index, uri, config);
+            window::open_webview(window_index, Some(uri), config);
         } else {
-            warn!("Skipping opening an empty buffer");
+            window::open_webview(window_index, self.engine.config.start_page(), config);
         }
     }
 


### PR DESCRIPTION
This changeset adds a few enhancements to the ways that commands can open new buffers.
1. Custom configurations. A command can now specify the configuration options to use when opening a buffer. These options are applied once and discarded.
2. Disabling JavaScript. JS can now be turned off on a per-site (or custom config) basis.
3. Chaining commands. Commands can now call other commands…so…have fun with that. Its worth noting that opening a buffer is asynchronous so calling `open_webview` then `run_command` will run the command in the old buffer.
4. Allow opening empty buffers. The reasoning behind disabling it was rather arbitrary, so it was removed to make this functionality easier.

Example usage, souped-up `buffernew`:

``` lua
function run()
  local windex = focused_window_index()
  if #arguments > 0 then
    local target = arguments[1]
    if target == "dev" then
      -- open a new buffer with common options for doing public software dev
      return open_with_config(windex, arguments[2], [[
      [general]
      private-browsing = false
      allow-plugins = false
      allow-javascript = false
      ]])
    elseif target == "tv" then
      -- open a new buffer with common options for watching stuff
      return open_with_config(windex, arguments[2], [[
      [general]
      private-browsing = false
      allow-plugins = true
      allow-javascript = true
      ]])
    else
      return open_with_defaults(windex, target)
    end
  end
  -- treat the target as a URL and open with defaults.
  return open_with_defaults(windex, lookup_string(config_file_path, "window.start-page"))
end

function open_with_defaults(windex, target)
  if windex ~= NOT_FOUND then
    open_webview(windex, target)
  else
    open_window(target)
  end
  return true
end

function open_with_config(windex, target, config)
  if target == nil then
    target = lookup_string(config_file_path, "window.start-page")
  end
  if windex ~= NOT_FOUND then
    open_custom_webview(windex, target, config)
  else
    open_custom_window(target, config)
  end
  return true
end
```

The subcommands above could then be mapped to different keybindings, like “Cmd+T” for `buffernew` vs “Cmd+Shift+T” for `buffernew dev`.
